### PR TITLE
Launcher: fix host cache not being used when checked if a host was a …

### DIFF
--- a/common/resolve.go
+++ b/common/resolve.go
@@ -18,7 +18,7 @@ func init() {
 	ClearCache()
 }
 
-func HostToIps(host string) []net.IP {
+func domainToIps(host string) []net.IP {
 	ips, err := net.LookupIP(host)
 	if err != nil {
 		return nil
@@ -109,7 +109,7 @@ func HostOrIpToIps(host string) []string {
 		return cachedIps.Clone().ToSlice()
 	}
 	var ips []string
-	ipsFromDns := HostToIps(host)
+	ipsFromDns := domainToIps(host)
 	if ipsFromDns != nil {
 		for _, ipRaw := range ipsFromDns {
 			ipStr := ipRaw.String()

--- a/launcher/internal/server/server.go
+++ b/launcher/internal/server/server.go
@@ -114,12 +114,12 @@ func GetExecutablePath(executable string) string {
 }
 
 func LanServerHost(id uuid.UUID, gameTitle string, host string, insecureSkipVerify bool) (ok bool) {
-	ipAddrs := common.HostToIps(host)
+	ipAddrs := common.HostOrIpToIps(host)
 	if len(ipAddrs) == 0 {
 		return
 	}
 	for _, ipAddr := range ipAddrs {
-		if ok, _, _, _ = lanServerIP(id, gameTitle, ipAddr, host, insecureSkipVerify, true); !ok {
+		if ok, _, _, _ = lanServerIP(id, gameTitle, net.ParseIP(ipAddr), host, insecureSkipVerify, true); !ok {
 			return
 		}
 	}


### PR DESCRIPTION
…LAN server increasing performance and fixing interoperability with AgeFakeHost.dll